### PR TITLE
Show target ship thumbnail for upgrade pledges

### DIFF
--- a/web_resources/HangarXPLOR.ParseUpgrade.js
+++ b/web_resources/HangarXPLOR.ParseUpgrade.js
@@ -21,5 +21,23 @@ HangarXPLOR.ParseUpgrade = function(pledgeName)
                                        .replace(/^ (- )?upgrade$/i, '')
                                        .replace(/^ (- )?Upgrade$/i, '')
                                        .replace(/^Upgrade (- )?/i, '');
+
+    // Show target ship thumbnail for upgrades
+    var $upgradeData = $('.js-upgrade-data', this);
+    if ($upgradeData.length > 0) {
+      try {
+        this.upgrade_data = JSON.parse($upgradeData.val());
+        var target_name = this.upgrade_data.target_items[0].name.trim();
+        var i, j;
+        for (i = 0, j = HangarXPLOR._shipMatrix.length; i < j; i++) {
+          if (target_name.toLowerCase().indexOf(HangarXPLOR._shipMatrix[i].name.toLowerCase()) > -1) {
+            if (HangarXPLOR._shipMatrix[i].thumbnail != undefined) {
+              $('.basic-infos .image', this).css({ 'background-image': 'url("' + HangarXPLOR._shipMatrix[i].thumbnail + '")'});
+            }
+            break;
+          }
+        }
+      } catch (e) { }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Parse the `.js-upgrade-data` hidden input field (provided by RSI) to extract the target ship name
- Match the target ship against the ship matrix and display its thumbnail instead of the default placeholder image
- This restores functionality present in the original [dolkensp/HangarXPLOR](https://github.com/dolkensp/HangarXPLOR) extension

**Note:** This feature works best in combination with PR #6 (sort comparator fix), which ensures that ship variants like "Golem OX" are matched before "Golem".

## Test plan

- [ ] Verify upgrade pledges show the target ship's image instead of "DEFAULT IMAGE"
- [ ] Verify non-upgrade pledges are unaffected
- [ ] Verify upgrades without `.js-upgrade-data` field gracefully fall back to default image

🤖 Generated with [Claude Code](https://claude.com/claude-code)